### PR TITLE
Apache bug fix

### DIFF
--- a/www/.htaccess
+++ b/www/.htaccess
@@ -5,7 +5,7 @@
 	RewriteCond %{REQUEST_FILENAME} !-f
 	# Prevent common static files from being loaded as pages
 	RewriteCond %{REQUEST_URI} !.*\.(ico|txt|css|jpg|jpeg|png|gif|bmp|zip|js|pdf)$
-	RewriteRule ^(.*)$ index.php?u=$1 [L,QSA]
+	RewriteRule ^(.*)$ /index.php?u=$1 [L,QSA]
 </IfModule>
 
 ErrorDocument 404 /index.php?u=error/404


### PR DESCRIPTION
Having the redirect to index.php instead of /index.php fixes a bug that ships with Apache on OS X in which a 500 response error is given: "Request exceeded the limit of # internal redirects due to probable configuration error."

I manage several Mac and Linux servers, this fixes the bug on the Mac's without changing behaviour on the Linux (also Apache) servers.
