### PR TITLE
Unexpected Behaviour fix

### DIFF
--- a/lib/Alloy/Kernel.php
+++ b/lib/Alloy/Kernel.php
@@ -404,7 +404,7 @@ class Kernel
         $sPluginClass = 'Plugin\\' . $sPlugin . '\Plugin';
         
         // Ensure class exists / can be loaded
-        if(!class_exists($sPluginClass)) {
+        if(!class_exists($sPluginClass, $init)) {
             return false;
         }
         

--- a/lib/Alloy/Kernel.php
+++ b/lib/Alloy/Kernel.php
@@ -411,7 +411,7 @@ class Kernel
         }
         
         // Ensure class exists / can be loaded
-        if(!class_exists($sPluginClass)) {
+        if(!class_exists($sPluginClass, $init)) {
             throw new \InvalidArgumentException("Unable to load plugin '" . $sPluginClass . "'. Remove from app config or ensure plugin files exist in 'app' or 'vendor' load paths.");
         }
         

--- a/www/.htaccess
+++ b/www/.htaccess
@@ -5,7 +5,7 @@
 	RewriteCond %{REQUEST_FILENAME} !-f
 	# Prevent common static files from being loaded as pages
 	RewriteCond %{REQUEST_URI} !.*\.(ico|txt|css|jpg|jpeg|png|gif|bmp|zip|js|pdf)$
-	RewriteRule ^(.*)$ index.php?u=$1 [L,QSA]
+	RewriteRule ^(.*)$ /index.php?u=$1 [L,QSA]
 </IfModule>
 
 ErrorDocument 404 /index.php?u=error/404


### PR DESCRIPTION
(sorry, I tried to only send commit 74f44fcc8af5326ba09b2c0c14c25385b90b80a5 with 1 file change into pull request, but github seems to be forcing both my commits in this pull request...)

Calling the plugin method always autoloads, despite $init variable being passed.  For example, if I wanted to see if Spot was loaded I would type: if ($kernel->plugin('Spot', false)) { // do stuff; }, but that will load spot.  Adding the false prevents the autoloader from running and thus only returns if it was previously loaded.
