### PR TITLE
Plugin check behaviour

### DIFF
--- a/lib/Alloy/Kernel.php
+++ b/lib/Alloy/Kernel.php
@@ -412,8 +412,12 @@ class Kernel
         }
         
         // Ensure class exists / can be loaded
-        if(!class_exists($sPluginClass, $init)) {
-            throw new \InvalidArgumentException("Unable to load plugin '" . $sPluginClass . "'. Remove from app config or ensure plugin files exist in 'app' or 'vendor' load paths.");
+        if(!class_exists($sPluginClass, (boolean)$init)) {
+            if ($init) {
+                throw new \InvalidArgumentException("Unable to load plugin '" . $sPluginClass . "'. Remove from app config or ensure plugin files exist in 'app' or 'vendor' load paths.");
+            }
+
+            return false;
         }
         
         // Instantiate module class

--- a/vendor/Plugin/Spot/lib/Spot/Adapter/PDO/Abstract.php
+++ b/vendor/Plugin/Spot/lib/Spot/Adapter/PDO/Abstract.php
@@ -384,7 +384,7 @@ abstract class PDO_Abstract extends AdapterAbstract implements AdapterInterface
             if($stmt) {
                 // Execute
                 if($stmt->execute($binds)) {
-                    $result = true;
+                    $result = $stmt->rowCount();
                 } else {
                     $result = false;
                 }

--- a/vendor/Plugin/Spot/lib/Spot/Mapper.php
+++ b/vendor/Plugin/Spot/lib/Spot/Mapper.php
@@ -291,6 +291,20 @@ class Mapper
         
         return $entity;
     }
+
+
+    /**
+     * Get a new entity object and set given data on it
+     *
+     * @param string $entityClass Name of the entity class
+     * @param array $data array of key/values to set on new Entity instance
+     * @return object INstance of $entityClass with $data set on it
+     */
+    public function create($entityClass, array $data)
+    {
+        return $this->get($entityClass)
+            ->data($data);
+    }
     
     
     /**
@@ -488,9 +502,7 @@ class Mapper
         if(is_object($entityName)) {
             $entity = $entityName;
             $entityName = get_class($entityName);
-            $conditions = array(
-                0 => array('conditions' => array($this->primaryKeyField($entityName) => $this->primaryKey($entity)))
-                );
+            $conditions = array($this->primaryKeyField($entityName) => $this->primaryKey($entity));
             // @todo Clear entity from identity map on delete, when implemented
         }
     


### PR DESCRIPTION
Kernel::plugin returns false when $init parameter is false - better expected behaviour when checking to see if a plugin is loaded.

Also added boolean typecast to class_exists call to prevent PHP warnings incase a wrong parameter was passed.
