### PR TITLE
dispatchRequest data merge

### DIFF
--- a/lib/Alloy/Kernel.php
+++ b/lib/Alloy/Kernel.php
@@ -488,9 +488,11 @@ class Kernel
             $action = $action . (false === strpos($action, 'Action') ? 'Action' : ''); // Append with 'Action' to limit scope of available functions from HTTP request
         }
         
-        // Prepend request object as first parameter
-        array_unshift($params, $request);
-        
+        foreach ($params as $key => $val) {
+            $request->$key = $val;
+        }
+        $params = Array($request);
+
         // Run normal dispatch
         return $this->dispatch($module, $action, $params);
     }


### PR DESCRIPTION
Merging parameters with dispatchRequest into Request object instead of opposite.

When a dispatchRequest was being called the action/method was receiving multiple parameters instead of the parameters being in the Alloy Request object.  The change merges the parameters into the Request object instead.
