### PR TITLE
Implementing afterMatch callback on router

### DIFF
--- a/alloy/lib/Alloy/Router.php
+++ b/alloy/lib/Alloy/Router.php
@@ -79,6 +79,14 @@ class Router
             }
         }
         
+        if ($params) {
+            // If we have an after match callback, we can use it to modify params
+            $mcb = $route->afterMatch();
+            if(null !== $mcb) {
+                $params = call_user_func($mcb, $params);
+            }
+        }
+
         return $params;
     }
     

--- a/alloy/lib/Alloy/Router/Route.php
+++ b/alloy/lib/Alloy/Router/Route.php
@@ -35,6 +35,7 @@ class Router_Route
 
     // Callbacks
     protected $_condition;
+    protected $_afterMatch;
     
     
     /**
@@ -295,5 +296,27 @@ class Router_Route
         }
 
         return $this->_condition;
+    }
+
+
+    /**
+     * After match callback
+     *
+     * @param callback $callback Callback function to be used to modify params after a successful match
+     * @throws \InvalidArgumentException When supplied argument is not a valid callback
+     * @return callback
+     */
+    public function afterMatch($callback = null)
+    {
+        // Setter
+        if(null !== $callback) {
+            if(!is_callable($callback)) {
+                throw new \InvalidArgumentException("The after match callback provided is not valid. Given (" . gettype($callback) . ")");
+            }
+            $this->_afterMatch = $callback;
+            return $this;
+        }
+
+        return $this->_afterMatch;
     }
 }

--- a/alloy/tests/Test/Router.php
+++ b/alloy/tests/Test/Router.php
@@ -176,4 +176,16 @@ class Test_Router extends \PHPUnit_Framework_TestCase
         $this->router->route('module', '/<:module>')
             ->condition('funnystuff');
     }
+
+    public function testRouteAfterMatchCallback()
+    {
+        $this->router->route('module', '/<:module>')
+            ->afterMatch(function($params) {
+                $params['module'] = 'someValue';
+                return $params;
+            });
+        
+        $params = $this->router->match("GET", "anything");
+        $this->assertEquals(array('module' => 'someValue'), $params);
+    }
 }


### PR DESCRIPTION
With the afterMatch callback it is possible to modify params' values returned by the router match method.
