### PR TITLE
Pass in the proper variable when calling ReflectionClass

### DIFF
--- a/alloy/lib/Alloy/Kernel.php
+++ b/alloy/lib/Alloy/Kernel.php
@@ -161,7 +161,7 @@ class Kernel
             $instance = new $className($params[0], $params[1], $params[2]);
         } else {
             $class = new \ReflectionClass($className);
-            $instance = $class->newInstanceArgs($args);
+            $instance = $class->newInstanceArgs($params);
         }
         
         return $this->setInstance($instanceHash, $instance);


### PR DESCRIPTION
A small change but allows for more than 3 parameters to be passed properly into the factory method.
